### PR TITLE
added custom properties to the api

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var ArenaXApi = (function () {
         _this.events = options.eventList;
         _this.configUrl = options.configUrl;
         _this.options = options;
+        _this.customProperties = options.customProperties;
 
         _this.observable.subscribe(function (data) {
             var storedAction = _this.actions.find(function (action) {


### PR DESCRIPTION
These properties can be useful when some arena wants to send some additional information to the game. For example, AARP can send a user`s login which can be used as an in-game username. 